### PR TITLE
Silent the 'press-enter-or-type-command-to-continue-prompt'

### DIFF
--- a/plugin/vimwiki-git.vim
+++ b/plugin/vimwiki-git.vim
@@ -6,7 +6,7 @@ augroup vimwiki
   " Make sure this window's working dir is the wiki repo dir whenever home.md is opened
   au! BufRead ~/vimwiki/home.md lcd ~/vimwiki
   " Also do a git pull whenever home.md is opened
-  au BufRead ~/vimwiki/home.md !git pull
+  au BufRead ~/vimwiki/home.md :silent !git pull
   " After writing to any file in the wiki dir, add all files in the repo, commit and push
   au! BufWritePost ~/vimwiki/* !git add .;git commit -m "Autocommit and push";git push
 augroup END


### PR DESCRIPTION
The "Press ENTER or type command to continue" prompt can be very annoying when opening the wiki. This PR will silence that prompt by adding `:silent` to the `!git pull` command.